### PR TITLE
Revert "Revert "Use <netinet/udp.h> instead of <linux/udp.h> on Andro…

### DIFF
--- a/src/racoon/isakmp.c
+++ b/src/racoon/isakmp.c
@@ -116,8 +116,8 @@
 #  ifndef SOL_UDP
 #   define SOL_UDP 17
 #  endif
-#if defined(ANDROID_CHANGES) && !defined(__linux)
-#define __linux
+#if defined(__ANDROID__)
+#include <netinet/udp.h>
 #endif
 # endif /* __linux__ */
 # if defined(__NetBSD__) || defined(__FreeBSD__) ||	\


### PR DESCRIPTION
…id.""

This reverts commit 8116a3ddb08abf5f996a12c11b389dc814714f84.

---

Actually this revert is giving errors on build. I suggest at the CM team to check this revert over the revert.
